### PR TITLE
Bump the ffmpeg group with 2 updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,8 +8,8 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
     <!-- To address transitive vulnerability -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="Xabe.FFmpeg" Version="6.0.1" />
-    <PackageVersion Include="Xabe.FFmpeg.Downloader" Version="6.0.1" />
+    <PackageVersion Include="Xabe.FFmpeg" Version="6.0.2" />
+    <PackageVersion Include="Xabe.FFmpeg.Downloader" Version="6.0.2" />
   </ItemGroup>
   <ItemGroup Label="Testing">
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />


### PR DESCRIPTION
Bumps Xabe.FFmpeg from 6.0.1 to 6.0.2
Bumps Xabe.FFmpeg.Downloader from 6.0.1 to 6.0.2

---
updated-dependencies:
- dependency-name: Xabe.FFmpeg dependency-version: 6.0.2 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: ffmpeg
- dependency-name: Xabe.FFmpeg.Downloader dependency-version: 6.0.2 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: ffmpeg ...